### PR TITLE
Добавлен конвертер дат во время миграции

### DIFF
--- a/src/Server/Students.DBCore/Contexts/PGContext.cs
+++ b/src/Server/Students.DBCore/Contexts/PGContext.cs
@@ -1,23 +1,50 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Logging;
 
 namespace Students.DBCore.Contexts;
 
 public sealed class PgContext : WorkContext
 {
-  protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-  {
-    optionsBuilder.UseNpgsql(
-      $"Host={Environment.GetEnvironmentVariable("DBServer")};Port={Environment.GetEnvironmentVariable("DBPort")};Database={Environment.GetEnvironmentVariable("DBName")};Username={Environment.GetEnvironmentVariable("DBLogin")};Password={Environment.GetEnvironmentVariable("DBPassword")};",
-      o => o.CommandTimeout(60));
-#if DEBUG
-    optionsBuilder.LogTo(Console.WriteLine, LogLevel.Information);
-#endif
-  }
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+             configurationBuilder.Properties<DateTime>()
+            .HaveConversion<UtcValueConverter>();
 
-  public PgContext()
-  {
-    //this.Database.EnsureDeleted();
-    this.Database.EnsureCreated();
-  }
+             configurationBuilder.Properties<DateTime?>()
+            .HaveConversion<UtcNullableValueConverter>();
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseNpgsql(
+            $"Host={Environment.GetEnvironmentVariable("DBServer")};Port={Environment.GetEnvironmentVariable("DBPort")};Database={Environment.GetEnvironmentVariable("DBName")};Username={Environment.GetEnvironmentVariable("DBLogin")};Password={Environment.GetEnvironmentVariable("DBPassword")};",
+            o => o.CommandTimeout(60));
+
+#if DEBUG
+        optionsBuilder.LogTo(Console.WriteLine, LogLevel.Information);
+#endif
+    }
+
+      public PgContext()
+    {
+    }
+}
+public class UtcValueConverter : ValueConverter<DateTime, DateTime>
+{
+    public UtcValueConverter()
+        : base(
+            v => v.ToUniversalTime(),
+            v => DateTime.SpecifyKind(v, DateTimeKind.Utc))
+    {
+    }
+}
+public class UtcNullableValueConverter : ValueConverter<DateTime?, DateTime?>
+{
+    public UtcNullableValueConverter()
+        : base(
+            v => v.HasValue ? v.Value.ToUniversalTime() : v,
+            v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : v)
+    {
+    }
 }


### PR DESCRIPTION
При создании БД локально, база данных создается с ошибками в формате дат. 
Добавлен конвертер дат.  
перед тем как выполнять Migration.bat:
dotnet tool install --global dotnet-ef
cd C:\cifra_repository\src\Server\Students.DBCore
dotnet ef migrations add AddColumnIsArchive --context="PGContext"
dotnet ef database update --context="PGContext"
 Удалить все миграции из папки GladCom\Cifralab\src\Server\Students.DBCore\Migrations в ней должен остаться только HasDataEntities.cs


